### PR TITLE
Update guided_code_challenges.ipynb

### DIFF
--- a/guided_code_challenges.ipynb
+++ b/guided_code_challenges.ipynb
@@ -351,7 +351,7 @@
    },
    "outputs": [],
    "source": [
-    "# Test Case 3: repeat_str(a, 'abc')\n",
+    "# Test Case 3: repeat_str(2, 'abc')\n",
     "print('Expected output: abcabc')\n",
     "print('Your function outputs: ', repeat_str(2, 'abc'))"
    ]
@@ -362,7 +362,7 @@
    "source": [
     "***\n",
     "## Challenge #4\n",
-    "### String repeat\n",
+    "### Century From Year\n",
     "**Introduction**\n",
     "The first century spans from the year 1 up to and including the year 100, The second - from the year 101 up to and including the year 200, etc.\n",
     "\n",


### PR DESCRIPTION
Spotted 2 typos in the Python Kata:
1. Kata 4 was called stringRepeat even though it's centuryFromYear
2. one of the stringRepeat examples had 'a' when instead of the number 2 